### PR TITLE
Automate npm deployment after successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+- '0.12'
+- '0.11'
+- '0.10'
 after_script:
-  - npm run coveralls
+- npm run coveralls
 deploy:
   provider: npm
   email: web-human@w3.org
   api_key:
-    secure: AyNgkrx7wfcH5ao3sfLBcB6puq5IW/kgiZput5Cj7CLp6rkR26XNmVH7MG0AgX1kGil/wAthzPJctvG8A5oc/bNsHMMttXjO6pP13VFU6Bv3IKSJF4mKUNXix0pt5ana93KEOXtN4F+66tHbmROsrLTdwnH3ehFd0zSa7Vs2Kwg=
+    secure: Jsn0BiPyfDf6ONzePv56cBPOC9j/A96XEiudRBRB29ugJNuYGKQGWey7wqnkYxQDJpeuyjOGdtY9aJ6ko0lPhlxdRjYAbNIx8OJO8s8wEWSvRoxB4/Yu3RgNLJ2ZhqBRz47n2dX5FIhh3WR3NnxWmAfxYDIPeLkHUP/J4v3cSbw=
   on:
     tags: true
     repo: w3c/insafe

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,11 @@ node_js:
   - "0.10"
 after_script:
   - npm run coveralls
+deploy:
+  provider: npm
+  email: web-human@w3.org
+  api_key:
+    secure: AyNgkrx7wfcH5ao3sfLBcB6puq5IW/kgiZput5Cj7CLp6rkR26XNmVH7MG0AgX1kGil/wAthzPJctvG8A5oc/bNsHMMttXjO6pP13VFU6Bv3IKSJF4mKUNXix0pt5ana93KEOXtN4F+66tHbmROsrLTdwnH3ehFd0zSa7Vs2Kwg=
+  on:
+    tags: true
+    repo: w3c/insafe


### PR DESCRIPTION
This PR makes Travis CI deploy on [npm](https://www.npmjs.com/~w3c) after a successful build, only when a new tag is pushed. To do so, [according to the doc](http://docs.travis-ci.com/user/deployment/npm/), on a clean repo (aka no uncommitted changes):

1. Run `npm version (major|minor|patch|x.y.z)` to (a) update the version number, (b) commit the change of version in `package.json`, and (c) create a tag in git, called `vx.y.z`.
2. Run `git push --follow-tags` (do not run `git push --tags`) to push the commit and the tag altogether, and Travis will take it from there.

Note that if the npm password changes, the encrypted `api_key` must be regenerated with (the lines start with a whitespace on purpose to not appear in the bash history):
```bash
 echo -n "w3c:[password]" | base64
 travis encrypt [result of the previous command]
```