### PR TITLE
Fix test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "insafe",
-  "version": "0.3.0",
-  "license": "MIT",
-  "author": "Guillaume Baudusseau <guillaume.baudusseau@gmail.com>",
-  "description": "Insafe is a Node.js package which resolves and checks that an URL is well-formed.",
-  "homepage": "https://github.com/w3c/insafe",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/w3c/insafe.git"
-  },
-  "main": "lib/insafe",
-  "dependencies": {
-    "when": "^3.7.3"
-  },
-  "devDependencies": {
-    "coveralls": "^2.11.2",
-    "istanbul": "^0.4.1",
-    "mocha": "^2.2.4"
-  },
-  "scripts": {
-    "coverage": "istanbul cover _mocha",
-    "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
-    "start": "node app.js",
-    "test": "mocha -c -G"
-  }
+    "name": "insafe",
+    "version": "0.3.0",
+    "license": "MIT",
+    "author": "Guillaume Baudusseau <guillaume.baudusseau@gmail.com>",
+    "description": "Insafe is a Node.js package which resolves and checks that an URL is well-formed.",
+    "homepage": "https://github.com/w3c/insafe",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/w3c/insafe.git"
+    },
+    "main": "lib/insafe",
+    "dependencies": {
+        "when": "3.7.7"
+    },
+    "devDependencies": {
+        "coveralls": "2.11.11",
+        "istanbul": "0.4.4",
+        "mocha": "2.5.3"
+    },
+    "scripts": {
+        "coverage": "istanbul cover _mocha",
+        "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
+        "start": "node app.js",
+        "test": "mocha -c -G"
+    }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -73,23 +73,18 @@ var tests = [
 	whitelist: ["www.w3.org"],
 	expected: false
     }
-
 ];
 
 describe('insafe library for node.js ', function() {
     describe('check method', function() {
 	tests.forEach(function(test) {
-	    if(test.expected == true) {
-		var message = test.url + ' should be safe.';
-	    } else {
-		var message = test.url + ' should not be safe.';
-	    }
+            var message = '“' + test.url + '” should ' + (test.expected ? '' : 'not ') + 'be safe.';
 	    it(message, function(done) {
 		insafe.check(test).then(function(res) {
 		    assert.equal(test.expected, res.status);
 		    done();
 		}).catch(function(err) {
-		    done();
+		    done(err);
 		});
 	    })
 	})

--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ var tests = [
 	statusCodesRefused: [],
 	blacklist: [],
 	whitelist: [],
-	expected: true
+	expected: false
     },
     {
 	url: 'terrybarth.com',
@@ -95,7 +95,7 @@ var tests = [
 	statusCodesRefused: [],
 	blacklist: [],
 	whitelist: [],
-	expected: true
+	expected: false
     },
     {
 	url: 'www.terrybarthdesign.com',
@@ -103,7 +103,7 @@ var tests = [
 	statusCodesRefused: [],
 	blacklist: [],
 	whitelist: [],
-	expected: true
+	expected: false
     }
 
 ];

--- a/test/test.js
+++ b/test/test.js
@@ -4,94 +4,94 @@ var insafe = require('..');
 var assert = require('assert');
 
 var tests = [
-	{
-		url: '',
-		statusCodesAccepted: [],
-		statusCodesRefused: [],
-		blacklist: [],
-		whitelist: [],
-		expected: false
-	},
-	{
-		url: 'foofoofoo',
-		statusCodesAccepted: [],
-		statusCodesRefused: [],
-		blacklist: [],
-		whitelist: [],
-		expected: false
-	},
-	{
-		url: 'http://www.google.com/',
-		expected: true
-	},
-	{
-		url: 'http://www.google.com/eewufhdsfsdjiiqwnd',
-		statusCodesAccepted: [],
-		statusCodesRefused: [],
-		blacklist: [],
-		whitelist: [],
-		expected: false
-	},
-	{
-		url: 'www.w3.org',
-		expected: true
-	},
-	{
-		url: 'w3.org',
-		statusCodesAccepted: ["301"],
-		expected: true
-	},
-	{
-		url: 'http://www.w3.org',
-		statusCodesAccepted: [],
-		statusCodesRefused: ["200"],
-		blacklist: [],
-		whitelist: [],
-		expected: false
-	},
-	{
-		url: 'http://www.w3.org',
-		statusCodesAccepted: ["200"],
-		statusCodesRefused: [],
-		blacklist: ["www.w3.org"],
-		whitelist: [],
-		expected: false
-	},
-	{
-		url: 'http://www.w3.org',
-		statusCodesAccepted: [],
-		statusCodesRefused: [],
-		blacklist: [],
-		whitelist: ["www.w3.org"],
-		expected: true
-	},
-	{
-		url: 'http://www.google.com',
-		statusCodesAccepted: [],
-		statusCodesRefused: [],
-		blacklist: [],
-		whitelist: ["www.w3.org"],
-		expected: false
-	}
+    {
+	url: '',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'foofoofoo',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'http://www.google.com/',
+	expected: true
+    },
+    {
+	url: 'http://www.google.com/eewufhdsfsdjiiqwnd',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'www.w3.org',
+	expected: true
+    },
+    {
+	url: 'w3.org',
+	statusCodesAccepted: ["301"],
+	expected: true
+    },
+    {
+	url: 'http://www.w3.org',
+	statusCodesAccepted: [],
+	statusCodesRefused: ["200"],
+	blacklist: [],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'http://www.w3.org',
+	statusCodesAccepted: ["200"],
+	statusCodesRefused: [],
+	blacklist: ["www.w3.org"],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'http://www.w3.org',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: ["www.w3.org"],
+	expected: true
+    },
+    {
+	url: 'http://www.google.com',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: ["www.w3.org"],
+	expected: false
+    }
 
 ];
 
 describe('insafe library for node.js ', function() {
-	describe('check method', function() {
-		tests.forEach(function(test) {
-			if(test.expected == true) {
-				var message = test.url + ' should be safe.';
-			} else {
-				var message = test.url + ' should not be safe.';
-			}
-			it(message, function(done) {
-				insafe.check(test).then(function(res) {
-					assert.equal(test.expected, res.status);
-					done();
-				}).catch(function(err) {
-					done();
-				});
-			})
-		})
-	});
+    describe('check method', function() {
+	tests.forEach(function(test) {
+	    if(test.expected == true) {
+		var message = test.url + ' should be safe.';
+	    } else {
+		var message = test.url + ' should not be safe.';
+	    }
+	    it(message, function(done) {
+		insafe.check(test).then(function(res) {
+		    assert.equal(test.expected, res.status);
+		    done();
+		}).catch(function(err) {
+		    done();
+		});
+	    })
+	})
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,40 @@ var tests = [
 	blacklist: [],
 	whitelist: ["www.w3.org"],
 	expected: false
+    },
+    {
+	url: 'http://http://wrong.address',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: false
+    },
+    {
+	url: 'happyness.life',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: true
+    },
+    {
+	url: 'terrybarth.com',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: true
+    },
+    {
+	url: 'www.terrybarthdesign.com',
+	statusCodesAccepted: [],
+	statusCodesRefused: [],
+	blacklist: [],
+	whitelist: [],
+	expected: true
     }
+
 ];
 
 describe('insafe library for node.js ', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -111,7 +111,7 @@ var tests = [
 describe('insafe library for node.js ', function() {
     describe('check method', function() {
 	tests.forEach(function(test) {
-            var message = '“' + test.url + '” should ' + (test.expected ? '' : 'not ') + 'be safe.';
+	    var message = '“' + test.url + '” should ' + (test.expected ? '' : 'not ') + 'be safe.';
 	    it(message, function(done) {
 		insafe.check(test).then(function(res) {
 		    assert.equal(test.expected, res.status);


### PR DESCRIPTION
I think the test suite was wrong: new tests would never fail with this logic. This fixes that.

* Make tests fail when they fail!
* Simplify code (4 lines &rarr; 1 line; remove redundant literals and if/else).
* Add 4 more URLs to test.
* Fix indentation (4 spaces instead of 8).

Note that **with this PR the test suite fails**, because I've added 3 URLs that have been reported to fail (see #8 and w3c/Mobile-Checker#125). But I think that it is right that it's wrong now :)

Now, to fix those 3 URLs, I believe some of [the options we're passing to `http.get()`](https://github.com/w3c/insafe/blob/master/lib/insafe.js#L271-L276) are responsible for those domains throwing an error. We have to fix that!